### PR TITLE
Ports call did not reflect correct endpoint

### DIFF
--- a/api-docs/getting-started/configuring-network-variations/sharing-ips-curl.rst
+++ b/api-docs/getting-started/configuring-network-variations/sharing-ips-curl.rst
@@ -231,7 +231,7 @@ this procedure.
    **List server A ports with cURL request**
 
    .. code::
-
+      $ API_ENDPOINT='https://dfw.networks.api.rackspacecloud.com'
       $ curl -s $API_ENDPOINT/ports?device_id=f387799f-9668-4cc7-9f0f-03c9cfc43af6 \
               -X GET \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
Added a variable on line 234 for API_ENDPOINT for the networks API which is where the ports call needs to be made.

**Quality audit reminder**

Doc team: While logged in using your O365 account, complete the quality checklist at http://bit.ly/2hwvBKX. Use the checklist for significant doc changes or additions submitted by you or a non-doc staff contributor.
